### PR TITLE
chore(docker): add visualization directory with nonroot ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN npm install pm2@latest -g
 
 COPY --chown=nonroot:nonroot . .
 
-RUN mkdir -p log && chown -R nonroot:nonroot log
+RUN mkdir -p logs workspace visualization && chown -R nonroot:nonroot logs workspace visualization
 
 RUN npm run build
 


### PR DESCRIPTION
> **Title:** Add `visualization` directory to Dockerfile with proper permissions

#### 📦 What's Changed
- Updated `Dockerfile` to include creation of a new `visualization` directory.
- Ensured the `visualization` directory, along with `logs` and `workspace`, is owned by the `nonroot` user to prevent permission issues at runtime.

#### ✅ Why
- Maintains consistency in directory permissions for non-root container environments.

#### 🔒 Security
- Follows best practices by ensuring non-root user access to necessary folders.

---